### PR TITLE
Add SEO tags to the home page, and the game#show page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,11 +18,11 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Functionality
-
 gem 'devise'
 gem 'will_paginate'
 gem 'acts_as_votable', '~> 0.10.0'
 gem 'ransack'
+gem 'metamagic'
 
 group :development, :test do
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    metamagic (3.1.7)
+      rails (>= 3.0.0)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
@@ -209,6 +211,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   letter_opener
+  metamagic
   pg
   rails (= 4.2.2)
   rails_12factor

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -105,7 +105,7 @@ class Game < ActiveRecord::Base
   private
 
   def request_game_data
-    url = 'http://store.steampowered.com/api/appdetails/?appids=#{steam_appid}'
+    url = "http://store.steampowered.com/api/appdetails/?appids=#{steam_appid}"
     resp = Net::HTTP.get_response(URI.parse(url))
     data = JSON.parse(resp.body)
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,3 +1,13 @@
+<% meta title: "#{@game.title} Reviews for PC" ,
+        description: "#{@game.title} reviews for PC platform.",
+        keywords: %w(@game.title pcmr pcmasterrace pcrating pcglorious),
+        og: {
+          title: "#{@game.title} Reviews for PC" ,
+          site_name: "PCMRating",
+          url: show_game_url(@game.steam_appid),
+          image: @game.header_image
+        } %>
+
 <div class="game-show-page">
   <div class="game-title">
     <h1><%= @game.title %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>PCMRating - Proper PC Game Reviews</title>
+    <%= metamagic site: "PCMRating", title: [:title, :site], separator: " — " %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= favicon_link_tag 'favicon.ico' %>

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,3 +1,13 @@
+<% meta title: "PCMRating - Proper PC Game Reviews",
+        description: "Game reviews for PC games done right.",
+        keywords: %w(pcmr pcmasterrace pcrating pcglorious),
+        og: {
+          title: "PCMRating - Proper PC Game Reviews",
+          site_name: "PCMRating",
+          url: "http://pcmrating.com",
+          image: "http://b.thumbs.redditmedia.com/WrXiojYMaBSCa2sTyJyZclFvQMo5ry9f6qOfrKo-2gc.png"
+        } %>
+
 <div class="landing">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
Added some nice SEO tags for the home page and the game's show page. 

For example if people search for "Batman PC reviews" we'll be nicely positioned in Google because our SEO is clear and concise.