### PR TITLE
Move all JS to the bottom of the layout.

### DIFF
--- a/app/assets/javascripts/application/games.js
+++ b/app/assets/javascripts/application/games.js
@@ -1,0 +1,7 @@
+$(document).ready(function() {
+  if ($('.game-index .headers').length) {
+    var sticky = new Waypoint.Sticky({
+      element: $('.game-index .headers')[0]
+    });
+  }
+});

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -73,9 +73,3 @@
   <%= will_paginate @reviews %>
 
 </div>
-
-<script>
-  var sticky = new Waypoint.Sticky({
-    element: $('.game-index .headers')[0]
-  })
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,22 +3,9 @@
   <head>
     <%= metamagic site: "PCMRating", title: [:title, :site], separator: " — " %>
     <%= stylesheet_link_tag    'application', media: 'all' %>
-    <%= javascript_include_tag 'application' %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-39137934-10', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-
   </head>
   <body>
 
@@ -35,11 +22,21 @@
 
     <%= render 'common/footer' %>
 
+    <%= javascript_include_tag 'application' %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-39137934-10', 'auto');
+      ga('send', 'pageview');
+
+    </script>
     <script>
       $.FancyNotifications.error("<%= flash[:error] %>");
       $.FancyNotifications.alert("<%= flash[:alert] %>");
       $.FancyNotifications.notice("<%= flash[:notice] %>");
     </script>
-
   </body>
 </html>


### PR DESCRIPTION
Having JS load in the head blocks the content from loading and showing visually.

http://stackoverflow.com/questions/11786915/javascript-on-the-bottom-of-the-page

This pull request moves the javascript to the bottom of the page and move the waypoints plugin into a separate .js file to avoid breaking the sticky waypoint.