### PR TITLE
Add og:description field for social cards.

### DIFF
--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,3 +1,14 @@
+<% meta title: "Games List",
+        description: "List of game reviews in PCMRating.",
+        keywords: %w(game list pcmr pcmasterrace pcrating pcglorious),
+        og: {
+          title: "Games List",
+          description: "List of game reviews in PCMRating.",
+          site_name: "PCMRating",
+          url: "http://pcmrating.com/games",
+          image: "http://b.thumbs.redditmedia.com/WrXiojYMaBSCa2sTyJyZclFvQMo5ry9f6qOfrKo-2gc.png"
+        } %>
+
 <div class="row">
   <div class="col-xs-6 col-xs-offset-3">
     <%= link_to 'Add a game', new_game_path, class: 'btn btn-info full-width' %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,7 +2,8 @@
         description: "#{@game.title} reviews for PC platform.",
         keywords: %w(@game.title pcmr pcmasterrace pcrating pcglorious),
         og: {
-          title: "#{@game.title} Reviews for PC" ,
+          title: "#{@game.title} Reviews for PC",
+          description: "#{@game.title} reviews for PC platform.",
           site_name: "PCMRating",
           url: game_url(@game.slug),
           image: @game.header_image

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -3,6 +3,7 @@
         keywords: %w(pcmr pcmasterrace pcrating pcglorious),
         og: {
           title: "PCMRating - Proper PC Game Reviews",
+          description: "Game reviews for PC games done right.",
           site_name: "PCMRating",
           url: "http://pcmrating.com",
           image: "http://b.thumbs.redditmedia.com/WrXiojYMaBSCa2sTyJyZclFvQMo5ry9f6qOfrKo-2gc.png"

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,8 +1,8 @@
-<% meta title: "PCMRating - Proper PC Game Reviews",
+<% meta title: "Proper PC Game Reviews",
         description: "Game reviews for PC games done right.",
         keywords: %w(pcmr pcmasterrace pcrating pcglorious),
         og: {
-          title: "PCMRating - Proper PC Game Reviews",
+          title: "Proper PC Game Reviews",
           description: "Game reviews for PC games done right.",
           site_name: "PCMRating",
           url: "http://pcmrating.com",


### PR DESCRIPTION
Facebook can infer the description, but Facebook recommends an explicit `og:description` tag.

![screen shot 2015-06-30 at 23 06 32](https://cloud.githubusercontent.com/assets/686715/8446730/abb9889e-1f7c-11e5-9562-5062dd2f5786.png)
